### PR TITLE
Add a standard penalty implementation

### DIFF
--- a/main.jl
+++ b/main.jl
@@ -9,10 +9,12 @@ max_steps = 500_000
 # m1, res1 = _run_optimization1(high_tfp, fosslim, penalty, max_steps)
 m2, res2 = _run_optimization2(high_tfp, fosslim, penalty, max_steps)
 m3, res3 = _run_optimization3(high_tfp, fosslim, max_steps)
+m4, res4 = _run_optimization4(high_tfp, fosslim, max_steps, 1e10)
 
 # explore(m1, title = "m1 - Penalty replaces total UTILITY")
 explore(m2, title = "m2 - Penalty in each year that exceeds fosslim")
 explore(m3, title = "m3 - Cora's way (forced abatement beyond fosslim)")
+explore(m4, title = "m4 - David's way (penalty factor)")
 
 # Gives the same solution for MIU to 3 decimal places
 isapprox.(m2[:emissions, :MIU][1:end-1], m3[:emissions, :final_MIU][1:end-1], atol=1e-3)


### PR DESCRIPTION
This might be even easier? Doesn't require any component modification, and I think this is a more like the [standard approach](https://en.wikipedia.org/wiki/Penalty_method). We could probably also square the penalty term. I'm not sure whether the step-wise increasing penalty coefficients would help with our evolutionary algorithm.